### PR TITLE
Add packaging dependency to resolve ModuleNotFoundError

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,6 @@
-name: 'Upload Android App Bundle to Google Play Store'
+name: 'Upload Android App Bundle to Google Play Store (fixed)'
 description: 'Uploads an Android App Bundle (.aab file) to the Google Play Store using the Play Developer API'
-author: Kevin Rohn
+author: excalibur-enterprise
 
 branding:
   icon: 'upload-cloud'
@@ -60,7 +60,7 @@ runs:
     - name: Install Google API Client Libraries
       shell: bash
       run: |
-        pip install --upgrade google-auth google-auth-oauthlib google-auth-httplib2 google-api-python-client
+        pip install --upgrade packaging google-auth google-auth-oauthlib google-auth-httplib2 google-api-python-client
 
     - name: Decode Service Account JSON and Save
       shell: bash


### PR DESCRIPTION
This pull request updates the metadata and dependencies for the GitHub Action that uploads Android App Bundles to the Google Play Store. The changes focus on clarifying authorship and ensuring required Python dependencies are installed.

Metadata updates:

* Changed the action name to `'Upload Android App Bundle to Google Play Store (fixed)'` and updated the author to `excalibur-enterprise` in `action.yml` for clearer identification and ownership.

Dependency management:

* Added the `packaging` Python package to the install step in `action.yml` to ensure all required libraries are present for the action to run correctly.