### PR TITLE
Fix large files upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This action allows you to automatically upload an Android App Bundle to the Goog
 ```yaml
 - name: Upload Android App Bundle to Google Play Store
   id: upload_aab
-  uses: KevinRohn/github-action-upload-play-store@v1.0.0
+  uses: KevinRohn/github-action-upload-play-store@v1.0.2
   with:
     service_account_json: ${{ secrets.SERVICE_ACCOUNT_JSON }}
     package_name: "com.example.myapp"
@@ -33,7 +33,7 @@ This action allows you to automatically upload an Android App Bundle to the Goog
 ```yaml
 - name: Upload .aab to Internal Track
   id: upload_internal
-  uses: KevinRohn/github-action-upload-play-store@v1.0.0
+  uses: KevinRohn/github-action-upload-play-store@v1.0.2
   with:
     service_account_json: ${{ secrets.SERVICE_ACCOUNT_JSON }}
     package_name: "com.example.myapp"
@@ -47,13 +47,28 @@ This action allows you to automatically upload an Android App Bundle to the Goog
 ```yaml
 - name: Upload .aab to Production Track
   id: upload_production
-  uses: KevinRohn/github-action-upload-play-store@v1.0.0
+  uses: KevinRohn/github-action-upload-play-store@v1.0.2
   with:
     service_account_json: ${{ secrets.SERVICE_ACCOUNT_JSON }}
     package_name: "com.example.myapp"
     aab_file_path: "./build/outputs/bundle/release/app-release.aab"
     track: "production"
     release_status: "completed"
+```
+
+### Upload a large AAB file with custom timeout
+
+```yaml
+- name: Upload Large .aab with Extended Timeout
+  id: upload_large_aab
+  uses: KevinRohn/github-action-upload-play-store@v1.0.2
+  with:
+    service_account_json: ${{ secrets.SERVICE_ACCOUNT_JSON }}
+    package_name: "com.example.myapp"
+    aab_file_path: "./build/outputs/bundle/release/app-release.aab"
+    track: "internal"
+    release_status: "draft"
+    timeout: 600
 ```
 
 ## Inputs
@@ -76,9 +91,14 @@ The action supports the following inputs:
   The track where you want to upload the `.aab` file. Available options: `internal`, `alpha`, `beta`, `production`, `rollout`.  
   **Required:** *true*
 
-- `release_status`  
-  Release status of the app. Available options: `draft`, `completed`, `halted`, `inProgress`.  
+- `release_status`
+  Release status of the app. Available options: `draft`, `completed`, `halted`, `inProgress`.
   **Required:** *true*
+
+- `timeout`
+  Timeout in seconds for upload operations.
+  **Required:** *false*
+  **Default:** `300`
 
 ## Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -24,6 +24,10 @@ inputs:
     description: 'Release status (e.g., draft, completed)'
     required: true
     default: 'draft'
+  timeout:
+    description: 'Timeout in seconds for upload operations'
+    required: false
+    default: '300'
 
 runs:
   using: 'composite'
@@ -73,12 +77,16 @@ runs:
         from google.oauth2.service_account import Credentials
         from googleapiclient.discovery import build
         from googleapiclient.http import MediaFileUpload
+        import httplib2
 
         credentials = Credentials.from_service_account_file(
             "service_account.json",
             scopes=["https://www.googleapis.com/auth/androidpublisher"]
         )
-        androidpublisher = build('androidpublisher', 'v3', credentials=credentials)
+
+        http = httplib2.Http(timeout=${{ inputs.timeout }})
+        authorized_http = credentials.authorize(http)
+        androidpublisher = build('androidpublisher', 'v3', http=authorized_http)
 
         edits = androidpublisher.edits()
         edit_request = edits.insert(body={}, packageName="${{ inputs.package_name }}")


### PR DESCRIPTION
**Action improvements:**

* Added a new `timeout` input to allow users to specify the upload operation timeout in seconds, defaulting to 300 seconds. (`action.yml`, `README.md`, [[1]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6R27-R30) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R98-R102)
* Updated the action's internal Python script to use the new `timeout` input when creating the HTTP client for Google API requests, improving support for large file uploads. (`action.yml`, [action.ymlR80-R89](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6R80-R89))

**Documentation updates:**

* Updated all usage examples in `README.md` to reference the latest action version (`v1.0.2`). [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L20-R20) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L36-R36) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L50-R50)
* Added an example in `README.md` showing how to upload a large `.aab` file with a custom timeout.
* Documented the new `timeout` input in the `README.md` inputs section.